### PR TITLE
Fix detection of versioned perl/ruby binaries

### DIFF
--- a/sbang
+++ b/sbang
@@ -78,13 +78,17 @@ EOF
 #
 # will be true for '#!/usr/bin/perl' and '#!/usr/bin/env perl'
 interpreter_is() {
-    if [ "${interpreter##*/}" = "$1" ]; then
-        return 0
-    elif [ "$interpreter" = "/usr/bin/env" ] && [ "$arg1" = "$1" ]; then
-        return 0
-    else
-        return 1
+    case "${interpreter##*/}" in
+        "$1"*) return 0 ;;
+    esac
+
+    if [ "$interpreter" = "/usr/bin/env" ]; then
+        case "$arg1" in
+            "$1"*) return 0 ;;
+        esac
     fi
+
+    return 1
 }
 
 if interpreter_is "sbang"; then

--- a/test/shebangs/perl-ver.pl
+++ b/test/shebangs/perl-ver.pl
@@ -1,0 +1,2 @@
+#!/usr/bin/env sbang
+#!/usr/bin/perl5.32.0

--- a/test/shebangs/ruby-ver.rb
+++ b/test/shebangs/ruby-ver.rb
@@ -1,0 +1,4 @@
+#!/usr/bin/env sbang
+#!/usr/bin/ruby2.7
+
+puts "ruby"

--- a/test/test-suite.sh
+++ b/test/test-suite.sh
@@ -34,6 +34,9 @@ equals "/usr/bin/env perl -w -x shebangs/perl-w-env.pl" $SBANG shebangs/perl-w-e
 equals "/usr/bin/ruby -x shebangs/ruby.rb"              $SBANG shebangs/ruby.rb
 equals "/usr/bin/env ruby -x shebangs/ruby-env.rb"      $SBANG shebangs/ruby-env.rb
 
+equals "/usr/bin/perl5.32.0 -x shebangs/perl-ver.pl"    $SBANG shebangs/perl-ver.pl
+equals "/usr/bin/ruby2.7 -x shebangs/ruby-ver.rb"       $SBANG shebangs/ruby-ver.rb
+
 equals "/usr/bin/python shebangs/python.py"             $SBANG shebangs/python.py
 equals "/usr/bin/env python shebangs/python-env.py"     $SBANG shebangs/python-env.py
 


### PR DESCRIPTION
Both perl and ruby can have versioned binaries, which sbang currently fails to detect. This PR adds support and two tests.